### PR TITLE
composer: remove `version` and require mercator 2.x (split-version)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
 	"name": "humanmade/mercator-gui",
 	"description": "Admin interface component for Mercator.",
 	"homepage": "https://github.com/humanmade/Mercator-GUI",
-	"version": "1.0.0",
 	"keywords": [
 		"wordpress"
 	],
@@ -17,6 +16,6 @@
 	"type": "wordpress-muplugin",
 	"require": {
 		"composer/installers": "~1.0",
-		"humanmade/mercator": "~1.0"
+		"humanmade/mercator": "~2.0"
 	 }
 }


### PR DESCRIPTION
composer `version` parameter should be omitted. SEE: https://getcomposer.org/doc/04-schema.md#version
```
Optional if the package repository can infer the version from somewhere,
such as the VCS tag name in the VCS repository. In that case it is also recommended to omit it.
```

mercator in the split-version should be required (call it 2.0 or 1.1)